### PR TITLE
Use augieschwer/telegraf-modem-monitor image.

### DIFF
--- a/configs/helm/telegraf.yaml
+++ b/configs/helm/telegraf.yaml
@@ -186,15 +186,6 @@ config:
           - "192.168.100.1"
           - "ping.sonic.net"
         method: "native"
-    - statsd:
-        service_address: ":8125"
-        percentiles:
-          - 50
-          - 95
-          - 99
-        metric_separator: "_"
-        allowed_pending_messages: 10000
-        percentile_limit: 1000
 metrics:
   health:
     enabled: false

--- a/configs/helm/telegraf.yaml
+++ b/configs/helm/telegraf.yaml
@@ -186,6 +186,11 @@ config:
           - "192.168.100.1"
           - "ping.sonic.net"
         method: "native"
+    - exec:
+        commands:
+          - "python3 /opt/scripts/parse_modem_status.py"
+        timeout: "30s"
+        data_format: "influx"
 metrics:
   health:
     enabled: false

--- a/configs/helm/telegraf.yaml
+++ b/configs/helm/telegraf.yaml
@@ -187,6 +187,7 @@ config:
           - "ping.sonic.net"
         method: "native"
     - exec:
+        interval: "5m"
         commands:
           - "python3 /opt/scripts/parse_modem_status.py"
         timeout: "30s"

--- a/configs/helm/telegraf.yaml
+++ b/configs/helm/telegraf.yaml
@@ -192,6 +192,15 @@ config:
           - "python3 /opt/scripts/parse_modem_status.py"
         timeout: "30s"
         data_format: "influx"
+    - statsd:
+        service_address: ":8125"
+        percentiles:
+          - 50
+          - 95
+          - 99
+        metric_separator: "_"
+        allowed_pending_messages: 10000
+        percentile_limit: 1000
 metrics:
   health:
     enabled: false

--- a/configs/helm/telegraf.yaml
+++ b/configs/helm/telegraf.yaml
@@ -1,11 +1,12 @@
 ## Default values.yaml for Telegraf
 ## This is a YAML-formatted file.
 ## ref: https://hub.docker.com/r/library/telegraf/tags/
+## https://hub.docker.com/r/augieschwer/telegraf-modem-monitor/tags/
 
 replicaCount: 1
 image:
-  repo: "docker.io/library/telegraf"
-  tag: "1.35-alpine"
+  repo: "augieschwer/telegraf-modem-monitor"
+  tag: "latest"
   pullPolicy: IfNotPresent
 podAnnotations: {}
 podLabels: {}


### PR DESCRIPTION
Use augieschwer/telegraf-modem-monitor image instead of official telegraf image for helm chart; this new image includes the python code to parse the sb8200 modem status pages, so now everything can run inside k8s.